### PR TITLE
(WIP) Add additional NO_GIT_LINKS tests

### DIFF
--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/lib/DirectoryFlagsTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/lib/DirectoryFlagsTest.java
@@ -1,19 +1,24 @@
 package org.eclipse.jgit.lib;
 
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.diff.RawTextComparator;
 import org.eclipse.jgit.junit.LocalDiskRepositoryTestCase;
+import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.util.FileUtils;
+import org.eclipse.jgit.util.io.DisabledOutputStream;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.PrintWriter;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DirectoryFlagsTest extends LocalDiskRepositoryTestCase {
-    @Test
-    public void testAddFileWithNoGitLinks() throws Exception {
+    private Repository createRepoWithNestedRepo() throws Exception {
         DirectoryFlags flags = new DirectoryFlags();
         flags.setNoGitLinks(true);
 
@@ -41,6 +46,12 @@ public class DirectoryFlagsTest extends LocalDiskRepositoryTestCase {
         writer.print("content");
         writer.close();
 
+        return db;
+    }
+    @Test
+    public void testAddFileWithNoGitLinks() throws Exception {
+        Repository db = createRepoWithNestedRepo();
+
         System.out.println("Calling add command");
         Git git = new Git(db);
         git.add().addFilepattern("sub/nested/a.txt").call();
@@ -51,6 +62,40 @@ public class DirectoryFlagsTest extends LocalDiskRepositoryTestCase {
                 indexState(db, CONTENT));
     }
 
-    // TODO: add a test for calling status after (and before?) doing
-    //  an add on a nested repo
+    @Test
+    public void testStatusWithNoGitLinks() throws Exception {
+        Repository db = createRepoWithNestedRepo();
+
+        Git git = new Git(db);
+
+        Status initialStatus = git.status().call();
+        assertTrue(initialStatus.getAdded().isEmpty());
+
+        git.add().addFilepattern("sub/nested/a.txt").call();
+
+        Status status = git.status().call();
+        assertTrue(status.getAdded().contains("sub/nested/a.txt"));
+    }
+
+    @Test
+    public void testCommitFileWithNoGitLinks() throws Exception {
+        Repository db = createRepoWithNestedRepo();
+
+        Git git = new Git(db);
+
+        git.add().addFilepattern("sub/nested/a.txt").call();
+        RevCommit commit = git.commit().setAuthor("false", "false@false.com").setMessage("test commit").call();
+
+        // Calculate the diff for the initial commit to ensure the
+        // subrepo's file was committed correctly
+        DiffFormatter df = new DiffFormatter(DisabledOutputStream.INSTANCE);
+        df.setRepository(db);
+        df.setDiffComparator(RawTextComparator.DEFAULT);
+        // Parent commit is null since this is the initial commit
+        DiffEntry diff = df.scan(null, commit.getTree()).get(0);
+
+        assertEquals("sub/nested/a.txt", diff.getNewPath());
+        assertEquals("100644", diff.getNewMode().toString());
+        assertEquals("ADD", diff.getChangeType().name());
+    }
 }


### PR DESCRIPTION
Add a test to ensure that a file added with the NO_GIT_LINKS flag
appears properly in a call to `git status`. Add a test to ensure
that a file added with the NO_GIT_LINKS flag is properly
committed.
